### PR TITLE
Make byte-encoding python 3.9 compatible

### DIFF
--- a/CapellaAPI.py
+++ b/CapellaAPI.py
@@ -18,8 +18,7 @@ class CapellaAPI(CapellaAPIRequests):
         self.perPage = 100
 
     def get_authorization_internal(self):
-        basic = base64.encodestring('{}:{}'.format(self.user, self.pwd).encode('utf-8')).decode('utf-8').strip("\n")
-        #basic = base64.encodestring('{}:{}'.format(self.user, self.pwd)).strip("\n")
+        basic = base64.encodebytes(bytes('{}:{}'.format(self.user, self.pwd), 'utf-8')).strip(b'\n').decode()
         header = {'Authorization': 'Basic %s' % basic}
         resp = self._urllib_request(
             "{}/sessions".format(self.internal_url), method="POST",

--- a/CapellaAPIAuth.py
+++ b/CapellaAPIAuth.py
@@ -42,8 +42,8 @@ class CapellaAPIAuth(AuthBase):
 
         # Calculate the hmac hash value with secret key and message
         cbc_api_signature = base64.b64encode(
-            hmac.new(bytes(self.SECRET_KEY),
-                     bytes(cbc_api_message),
+            hmac.new(bytes(self.SECRET_KEY, 'utf-8'),
+                     bytes(cbc_api_message, 'utf-8'),
                      digestmod=hashlib.sha256).digest())
 
         # Values for the header


### PR DESCRIPTION
In perfrunner we use python 3.9.7, and where we do base64 encoding currently is not valid in Python 3.9.