### PR TITLE
Refactor the "allow ip" endpoint methods

### DIFF
--- a/CapellaAPI.py
+++ b/CapellaAPI.py
@@ -278,15 +278,30 @@ class CapellaAPI(CapellaAPIRequests):
                                     headers=capella_header)
         return resp
 
-    def add_allowed_ip(self, tenant_id, project_id, cluster_id):
+    def allow_my_ip(self, tenant_id, project_id, cluster_id):
         capella_header = self.get_authorization_internal()
         url = '{}/v2/organizations/{}/projects/{}/clusters/{}'\
             .format(self.internal_url, tenant_id, project_id, cluster_id)
         resp = self._urllib_request("https://ifconfig.me", method="GET")
         if resp.status_code != 200:
             raise Exception("Fetch public IP failed!")
-        body = {"create": [{"cidr": "{}/32".format(resp.content),
+        body = {"create": [{"cidr": "{}/32".format(resp.content.decode()),
                             "comment": ""}]}
+        url = '{}/allowlists-bulk'.format(url)
+        resp = self._urllib_request(url, method="POST",
+                                    params=json.dumps(body),
+                                    headers=capella_header)
+        return resp
+
+    def add_allowed_ips(self, tenant_id, project_id, cluster_id, ips):
+        capella_header = self.get_authorization_internal()
+        url = '{}/v2/organizations/{}/projects/{}/clusters/{}'\
+            .format(self.internal_url, tenant_id, project_id, cluster_id)
+        body = {
+            "create": [
+                {"cidr": "{}/32".format(ip), "comment": ""} for ip in ips
+            ]
+        }
         url = '{}/allowlists-bulk'.format(url)
         resp = self._urllib_request(url, method="POST",
                                     params=json.dumps(body),


### PR DESCRIPTION
Previously, the method named `add_allowed_ip` only added the IP of the machine running the code (your own IP typically) and did not support allowing more IPs.

For performance tests we need to be able to add potentially multiple other allowed IPs, so I've added a method to do that. I've named this new method `add_allowed_ips` and it takes a list of IPs to allow. I've renamed `add_allowed_ip` to `allow_my_ip` to avoid ambiguity.