### PR TITLE
Add methods for deploying cluster with overriden AMI

### DIFF
--- a/CapellaAPI.py
+++ b/CapellaAPI.py
@@ -243,7 +243,7 @@ class CapellaAPI(CapellaAPIRequests):
 
     def create_cluster_internal(self, tenant_id, cluster_params):
         capella_header = self.get_authorization_internal()
-        url = '{}/v2/organizations/{}//clusters/deploy'\
+        url = '{}/v2/organizations/{}/clusters/deploy'\
               .format(self.internal_url, tenant_id)
 
         resp = self._urllib_request(url, method="POST", params=cluster_params,


### PR DESCRIPTION
Add methods for using 2 more internal API endpoints:

`/v2/organizations/TENANT_ID/clusters/deploy` allows one to deploy a cluster while specifying a non-default AMI to use.

`/v2/organizations/TENANT_ID/clusters/deployment-options` gets a bunch of deployment-related information about the tenant, including the "suggestedCidr" which is useful for using the deployment endpoint above (otherwise you may hit CIDR conflict issues).