### PR TITLE
Don't skip TLS verification

### DIFF
--- a/CapellaAPIRequests.py
+++ b/CapellaAPIRequests.py
@@ -42,8 +42,7 @@ class CapellaAPIRequests(object):
         try:
             cbc_api_response = self.network_session.get(
                 self.API_BASE_URL + api_endpoint,
-                auth=CapellaAPIAuth(self.SECRET, self.ACCESS),
-                verify=False)
+                auth=CapellaAPIAuth(self.SECRET, self.ACCESS))
             self._log.debug(cbc_api_response.content)
 
         except requests.exceptions.HTTPError:
@@ -75,8 +74,7 @@ class CapellaAPIRequests(object):
             cbc_api_response = self.network_session.post(
                 self.API_BASE_URL + api_endpoint,
                 json=request_body,
-                auth=CapellaAPIAuth(self.SECRET, self.ACCESS),
-                verify=False)
+                auth=CapellaAPIAuth(self.SECRET, self.ACCESS))
             self._log.debug(cbc_api_response.content)
 
         except requests.exceptions.HTTPError:
@@ -106,8 +104,7 @@ class CapellaAPIRequests(object):
             cbc_api_response = self.network_session.put(
                 self.API_BASE_URL + api_endpoint,
                 json=request_body,
-                auth=CapellaAPIAuth(self.SECRET, self.ACCESS),
-                verify=False)
+                auth=CapellaAPIAuth(self.SECRET, self.ACCESS))
             self._log.debug(cbc_api_response.content)
 
         except requests.exceptions.HTTPError:
@@ -132,14 +129,12 @@ class CapellaAPIRequests(object):
             if request_body is None:
                 cbc_api_response = self.network_session.delete(
                     self.API_BASE_URL + api_endpoint,
-                    auth=CapellaAPIAuth(self.SECRET, self.ACCESS),
-                    verify=False)
+                    auth=CapellaAPIAuth(self.SECRET, self.ACCESS))
             else:
                 cbc_api_response = self.network_session.delete(
                     self.API_BASE_URL + api_endpoint,
                     json=request_body,
-                    auth=CapellaAPIAuth(self.SECRET, self.ACCESS),
-                    verify=False)
+                    auth=CapellaAPIAuth(self.SECRET, self.ACCESS))
 
             self._log.debug(cbc_api_response.content)
 
@@ -161,21 +156,21 @@ class CapellaAPIRequests(object):
         return (cbc_api_response)
 
     def _urllib_request(self, api, method='GET', headers=None,
-                        params='', timeout=300, verify=False):
+                        params='', timeout=300):
         session = requests.Session()
         try:
             if method == "GET":
                 resp = session.get(api, params=params, headers=headers,
-                                   timeout=timeout, verify=verify)
+                                   timeout=timeout)
             elif method == "POST":
                 resp = session.post(api, data=params, headers=headers,
-                                    timeout=timeout, verify=verify)
+                                    timeout=timeout)
             elif method == "DELETE":
                 resp = session.delete(api, data=params, headers=headers,
-                                      timeout=timeout, verify=verify)
+                                      timeout=timeout)
             elif method == "PUT":
                 resp = session.put(api, data=params, headers=headers,
-                                   timeout=timeout, verify=verify)
+                                   timeout=timeout)
             return resp
         except requests.exceptions.HTTPError as errh:
             self._log.error("HTTP Error {0}".format(errh))


### PR DESCRIPTION
All APIs have valid tls certificates so there is no need to skip verification
It removes this messy output

```
pi.dev.nonprod-project-avengers.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
/Users/jakerawsthorne/Code/couchbase/testrunner/.venv/lib/python3.7/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.dev.nonprod-project-avengers.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
/Users/jakerawsthorne/Code/couchbase/testrunner/.venv/lib/python3.7/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.dev.nonprod-project-avengers.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
/Users/jakerawsthorne/Code/couchbase/testrunner/.venv/lib/python3.7/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.dev.nonprod-project-avengers.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
2022-07-04 10:37:11 | INFO | MainProcess | test_thread | [CapellaAPIRequests.capella_api_get] /v3/clusters/e45e3389-d9a1-4313-84c1-09e76cc4a9bb
/Users/jakerawsthorne/Code/couchbase/testrunner/.venv/lib/python3.7/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cloudapi.dev.nonprod-project-avengers.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
/Users/jakerawsthorne/Code/couchbase/testrunner/.venv/lib/python3.7/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.dev.nonprod-project-avengers.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
/Users/jakerawsthorne/Code/couchbase/testrunner/.venv/lib/python3.7/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.dev.nonprod-project-avengers.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
2022-07-04 10:37:15 | INFO | MainProcess | test_thread | [CapellaAPIRequests.capella_api_get] /v3/clusters/e45e3389-d9a1-4313-84c1-09e76cc4a9bb
/Users/jakerawsthorne/Code/couchbase/testrunner/.venv/lib/python3.7/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cloudapi.dev.nonprod-project-avengers.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
```